### PR TITLE
Handle empty CFB DataFrames

### DIFF
--- a/data_ingestors.py
+++ b/data_ingestors.py
@@ -84,7 +84,18 @@ def fetch_cfb_results_games(season: int) -> pd.DataFrame:
                 "neutral": int(comp.get("neutralSite") or 0),
                 "playoff": 0,
             })
-    return pd.DataFrame(rows)
+    cols = [
+        "season",
+        "week",
+        "date",
+        "home_team",
+        "away_team",
+        "home_score",
+        "away_score",
+        "neutral",
+        "playoff",
+    ]
+    return pd.DataFrame(rows, columns=cols)
 
 def fetch_cfb_schedule_week(season: int, week: int) -> pd.DataFrame:
     params = {"week": week, "seasontype": 2, "dates": season}
@@ -104,7 +115,8 @@ def fetch_cfb_schedule_week(season: int, week: int) -> pd.DataFrame:
                      "home_team": h_abbr,
                      "away_team": a_abbr,
                      "neutral": neutral})
-    return pd.DataFrame(rows)
+    cols = ["season", "week", "date", "home_team", "away_team", "neutral"]
+    return pd.DataFrame(rows, columns=cols)
 def recent_form_feature(results: pd.DataFrame, window_games: int = 4) -> pd.DataFrame:
     long_rows = []
     for _, r in results.iterrows():


### PR DESCRIPTION
## Summary
- Ensure `fetch_cfb_results_games` always returns a DataFrame with expected columns
- Ensure `fetch_cfb_schedule_week` provides column structure even when no games exist

## Testing
- `python -m py_compile data_ingestors.py weekly_loop_cfb.py`
- `python weekly_loop_cfb.py --db test_cfb.sqlite --season 3025 --week 1` *(fails: HTTPSConnectionPool(host='site.api.espn.com', port=443): Max retries exceeded with url: ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b2148a0b98832f93a71e8653739c6c