### PR TITLE
Handle empty CFB DataFrames

### DIFF
--- a/compare_odds.py
+++ b/compare_odds.py
@@ -1,12 +1,27 @@
 from __future__ import annotations
+
 import argparse
 from pathlib import Path
-import pandas as pd, numpy as np
+
+import numpy as np
+import pandas as pd
+
 from odds_ingestor import odds_with_implied_probs
+
 DEF_THRESH = 0.15
+
+
 def main(season: int, week: int, blended_csv: str, outdir: str, threshold: float = DEF_THRESH):
-    preds = pd.read_csv(blended_csv); odds = odds_with_implied_probs(season, week)
-    if preds.empty or odds.empty: print("Missing inputs; preds or odds empty."); return
+    path = Path(blended_csv)
+    if not path.is_file():
+        print(f"Blended predictions file not found: {blended_csv}")
+        return
+
+    preds = pd.read_csv(path)
+    odds = odds_with_implied_probs(season, week)
+    if preds.empty or odds.empty:
+        print("Missing inputs; preds or odds empty.")
+        return
     merged = preds.merge(odds, on=["home_team","away_team"], how="inner")
     p_model = merged["p_home_win_blended"].astype(float) if "p_home_win_blended" in merged.columns else merged["p_home_win"].astype(float)
     p_market = merged["p_home_impl"].astype(float).fillna(0.5)

--- a/data_ingestors.py
+++ b/data_ingestors.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
-import pandas as pd, numpy as np, requests
+
 from typing import Dict, List
+
+import numpy as np
+import pandas as pd
+import requests
+import nfl_data_py as nfl
+
+from cfb_teams import POWER_FIVE_TEAMS
+
 NFL_GAMES_URL = "https://github.com/nflverse/nflverse-data/releases/download/games/games.csv.gz"
 ESPN_SCOREBOARD = "https://site.api.espn.com/apis/v2/sports/football/nfl/scoreboard"
 CFB_SCOREBOARD = "https://site.api.espn.com/apis/v2/sports/football/college-football/scoreboard"
-import pandas as pd, numpy as np, requests
-from cfb_teams import POWER_FIVE_TEAMS
-import nfl_data_py as nfl
 
 TEAM_NORMALIZE = {"WSH": "WAS", "LA": "LAR", "OAK": "LV", "SD": "LAC"}
 
@@ -32,9 +37,9 @@ def fetch_results_games(season: int) -> pd.DataFrame:
         "playoff": 0,
     })
     if "game_type" in df.columns:
-        out["playoff"] = np.where(df["game_type"].isin(["WC","DIV","CON","SB","P","POST"]), 1, 0).astype(int)
-
-        out["playoff"] = np.where(df["game_type"].isin(["WC","DIV","CON","SB","P","POST"]), 1, 0).astype(int)
+        out["playoff"] = np.where(
+            df["game_type"].isin(["WC", "DIV", "CON", "SB", "P", "POST"]), 1, 0
+        ).astype(int)
     return out
 
 def fetch_schedule_week(season: int, week: int) -> pd.DataFrame:
@@ -84,7 +89,18 @@ def fetch_cfb_results_games(season: int) -> pd.DataFrame:
                 "neutral": int(comp.get("neutralSite") or 0),
                 "playoff": 0,
             })
-    return pd.DataFrame(rows)
+    cols = [
+        "season",
+        "week",
+        "date",
+        "home_team",
+        "away_team",
+        "home_score",
+        "away_score",
+        "neutral",
+        "playoff",
+    ]
+    return pd.DataFrame(rows, columns=cols)
 
 def fetch_cfb_schedule_week(season: int, week: int) -> pd.DataFrame:
     params = {"week": week, "seasontype": 2, "dates": season}
@@ -104,7 +120,8 @@ def fetch_cfb_schedule_week(season: int, week: int) -> pd.DataFrame:
                      "home_team": h_abbr,
                      "away_team": a_abbr,
                      "neutral": neutral})
-    return pd.DataFrame(rows)
+    cols = ["season", "week", "date", "home_team", "away_team", "neutral"]
+    return pd.DataFrame(rows, columns=cols)
 def recent_form_feature(results: pd.DataFrame, window_games: int = 4) -> pd.DataFrame:
     long_rows = []
     for _, r in results.iterrows():


### PR DESCRIPTION
## Summary
- Ensure `fetch_cfb_results_games` always returns a DataFrame with expected columns
- Ensure `fetch_cfb_schedule_week` provides column structure even when no games exist
- Skip odds comparison when blended predictions are missing to avoid CLI failures

## Testing
- `python -m py_compile data_ingestors.py compare_odds.py weekly_loop_cfb.py`
- `python weekly_loop_cfb.py --db test_cfb.sqlite --season 3025 --week 1` *(fails: HTTPSConnectionPool(host='site.api.espn.com', port=443): Max retries exceeded ...)*
- `python compare_odds.py --season 2025 --week 1 --blended missing.csv`


------
https://chatgpt.com/codex/tasks/task_e_68b2148a0b98832f93a71e8653739c6c